### PR TITLE
Refactor test to use graph equality check for conciseness / accuracy

### DIFF
--- a/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
+++ b/logstash-core/src/main/java/org/logstash/config/ir/DSL.java
@@ -303,6 +303,9 @@ public class DSL {
         return gPlugin(meta, type, pluginName, new HashMap<>());
     }
 
+    public static PluginVertex gPlugin(SourceWithMetadata meta, PluginDefinition pluginDefinition) {
+        return gPlugin(meta, pluginDefinition.getType(), pluginDefinition.getName(), pluginDefinition.getArguments());
+    }
 
     public static IfVertex gIf(SourceWithMetadata meta, BooleanExpression expression) {
        return new IfVertex(meta, expression);

--- a/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
+++ b/logstash-core/src/test/java/org/logstash/config/ir/imperative/IfStatementTest.java
@@ -7,10 +7,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.util.stream.Stream;
 
+import org.logstash.common.SourceWithMetadata;
+import org.logstash.config.ir.DSL;
 import org.logstash.config.ir.InvalidIRException;
-import org.logstash.config.ir.graph.BooleanEdge;
-import org.logstash.config.ir.graph.Graph;
-import org.logstash.config.ir.graph.Vertex;
+import org.logstash.config.ir.PluginDefinition;
+import org.logstash.config.ir.expression.BooleanExpression;
+import org.logstash.config.ir.expression.Expression;
+import org.logstash.config.ir.graph.*;
 
 import static org.logstash.config.ir.IRHelpers.*;
 
@@ -33,33 +36,27 @@ public class IfStatementTest {
 
     @Test
     public void testIfWithOneTrueStatement() throws InvalidIRException {
+        PluginDefinition pluginDef = testPluginDefinition();
         Statement trueStatement = new PluginStatement(randMeta(), testPluginDefinition());
         Statement falseStatement = new NoopStatement(randMeta());
+        BooleanExpression ifExpression = createTestExpression();
         IfStatement ifStatement = new IfStatement(
                 randMeta(),
-                createTestExpression(),
+                ifExpression,
                 trueStatement,
                 falseStatement
         );
 
         Graph ifStatementGraph = ifStatement.toGraph();
         assertFalse(ifStatementGraph.isEmpty());
+        
+        Graph expected = new Graph();
+        IfVertex expectedIf = DSL.gIf(randMeta(), ifExpression);
+        expected.addVertex(expectedIf);
+        PluginVertex expectedT = DSL.gPlugin(randMeta(), testPluginDefinition());
+        expected.chainVertices(true, expectedIf, expectedT);
 
-        Stream<Vertex> trueVertices = ifStatementGraph
-                .edges()
-                .filter(e -> e instanceof BooleanEdge)
-                .map(e -> (BooleanEdge) e)
-                .filter(e -> e.getEdgeType() == true)
-                .map(e -> e.getTo());
-        assertEquals(1, trueVertices.count());
-
-        Stream<Vertex> falseVertices = ifStatementGraph
-                .edges()
-                .filter(e -> e instanceof BooleanEdge)
-                .map(e -> (BooleanEdge) e)
-                .filter(e -> e.getEdgeType() == false)
-                .map(e -> e.getTo());
-        assertEquals(0, falseVertices.count());
+        assertSyntaxEquals(expected, ifStatementGraph);
     }
 
 


### PR DESCRIPTION
I think we should use this pattern for the rest of the tests. It tests more accurately than pure counts since we diff the full graph, and it's shorter to boot.